### PR TITLE
Simplify assertions with NumPy

### DIFF
--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -81,7 +81,7 @@ class TestUltimateTicTacToeBoard:
         assert success
 
         # Check that the move was made
-        assert board.board[position.board_y, position.board_x] == Player.X.value
+        np.testing.assert_equal(board.board[position.board_y, position.board_x], Player.X.value)
         assert board.last_move == position
         assert board.current_player == Player.O
 
@@ -119,7 +119,7 @@ class TestUltimateTicTacToeBoard:
         board.set_board_state(board_state, Player.O, Position(2))
 
         # Sub-board 0 should be won by X
-        assert board.subboard_winner[0, 0] == Player.X.value
+        np.testing.assert_equal(board.subboard_winner[0, 0], Player.X.value)
 
         # Since sub-board 0 is won, next moves can be played anywhere except sub-board 0
         legal_moves = board.get_legal_moves()
@@ -214,7 +214,7 @@ class TestUltimateTicTacToeBoard:
 
         # Check what position was actually filled
         # Position 40 should be at board coordinates (4, 4)
-        assert board.board[4, 4] == Player.X.value
+        np.testing.assert_equal(board.board[4, 4], Player.X.value)
 
         # Check legal moves after first move
         legal_moves = board.get_legal_moves()

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -64,7 +64,7 @@ class TestUltimateTicTacToeEnv:
 
         # Check observation
         assert observation.shape == (9, 9)
-        assert observation[4, 4] == 1  # X's move
+        np.testing.assert_equal(observation[4, 4], 1)  # X's move
 
         # Check reward (should be 0 for non-terminal state)
         assert reward == 0.0


### PR DESCRIPTION
Direct array comparisons in test assertions were replaced with `np.testing.assert_equal` for improved error messages.

Specifically, changes were applied to:
*   `tests/test_board.py`:
    *   Line 83: `assert board.board[position.board_y, position.board_x] == Player.X.value` became `np.testing.assert_equal(board.board[position.board_y, position.board_x], Player.X.value)`.
    *   Line 121: `assert board.subboard_winner[0, 0] == Player.X.value` became `np.testing.assert_equal(board.subboard_winner[0, 0], Player.X.value)`.
    *   Line 216: `assert board.board[4, 4] == Player.X.value` became `np.testing.assert_equal(board.board[4, 4], Player.X.value)`.
*   `tests/test_env.py`:
    *   Line 66: `assert observation[4, 4] == 1` became `np.testing.assert_equal(observation[4, 4], 1)`.

This change provides more informative error messages on test failure, displaying actual versus desired values and their types (e.g., `ACTUAL: np.int8(1) DESIRED: 999`), which significantly aids in debugging compared to a generic `AssertionError`. The modifications were verified by running existing tests and confirming the improved error message format.