### PR TITLE
Set up reinforcement learning pipeline

### DIFF
--- a/RL_SETUP.md
+++ b/RL_SETUP.md
@@ -1,0 +1,165 @@
+# Ultimate Tic-Tac-Toe 強化学習パイプライン セットアップガイド
+
+## 📋 概要
+
+このリポジトリに **4つのファイルだけ追加** してStable Baselines 3による強化学習パイプラインを構築しました：
+
+- `env_registration.py` - Gymnasium環境登録
+- `config.yaml` - ハイパーパラメータ設定  
+- `train_rl.py` - 学習スクリプト
+- `evaluate_rl.py` - 評価スクリプト
+
+## 🚀 セットアップ手順
+
+### 1. 依存関係のインストール
+
+```bash
+# 仮想環境を作成（推奨）
+python3 -m venv venv
+source venv/bin/activate
+
+# 必要なライブラリをインストール
+pip install "stable-baselines3[extra]>=2.3" "gymnasium[all]>=1.0" pyyaml torch
+```
+
+### 2. 動作確認
+
+環境が正しく登録されるかテスト：
+
+```bash
+python3 -c "import env_registration; import gymnasium as gym; env = gym.make('UTTTRLSim-v0'); print('Environment registered successfully!'); print(f'Observation space: {env.observation_space}'); print(f'Action space: {env.action_space}')"
+```
+
+## 🎯 使用方法
+
+### 学習の実行
+
+```bash
+# デフォルト設定で学習開始
+python3 train_rl.py
+
+# TensorBoardでログ監視（別ターミナル）
+tensorboard --logdir logs/tb
+```
+
+### 学習済みモデルの評価
+
+```bash
+# 100エピソードで評価
+python3 evaluate_rl.py
+
+# エピソード数を指定
+python3 evaluate_rl.py --episodes 50
+
+# 描画モードで実行
+python3 evaluate_rl.py --render --episodes 5
+```
+
+## ⚙️ 設定カスタマイズ
+
+`config.yaml` を編集して学習パラメータを調整：
+
+```yaml
+env_id: UTTTRLSim-v0
+n_envs: 16          # 並列環境数（CPUコア数に応じて調整）
+total_steps: 2000000 # 学習ステップ数
+seed: 42
+
+ppo_params:
+  learning_rate: 0.0003
+  batch_size: 4096    # バッチサイズ
+  n_steps: 2048
+  # その他PPOパラメータ...
+```
+
+## 📊 期待される結果
+
+### 学習進行例
+```
+Creating 8 environments...
+Using Metal Performance Shaders (MPS) backend  # Apple Silicon
+Creating PPO model...
+Starting training for 1000000 steps...
+---------------------------------
+| rollout/           |          |
+|    ep_len_mean     | 45.2     |
+|    ep_rew_mean     | 0.125    |
+| time/              |          |
+|    fps             | 2847     |
+|    iterations      | 100      |
+|    time_elapsed    | 72       |
+|    total_timesteps | 204800   |
+...
+```
+
+### 評価結果例
+```
+=== Evaluation Results ===
+Episodes: 100
+Mean reward: 0.65 ± 0.32
+🎉 Agent is performing well! (mostly winning)
+```
+
+## 🛠️ トラブルシューティング
+
+### よくある問題と解決策
+
+**Q. `ModuleNotFoundError: No module named 'utttrlsim'`**
+```bash
+# プロジェクトルートから実行していることを確認
+export PYTHONPATH="${PYTHONPATH}:$(pwd)/src"
+python3 train_rl.py
+```
+
+**Q. Apple Silicon Macで「MPS backend not available」**
+```bash
+# PyTorchを最新版にアップデート
+pip install --upgrade torch
+```
+
+**Q. 学習が遅い**
+- `config.yaml`の`n_envs`を増やす（CPUコア数まで）
+- `batch_size`と`n_steps`を調整
+- GPUが使える場合は自動で使用されます
+
+**Q. 他のRLライブラリに移行したい**
+- `env_registration.py`はそのまま使用可能
+- TorchRL、RLlib等でも同じ`gym.make("UTTTRLSim-v0")`が使えます
+
+## 📁 ファイル構成
+
+```
+your-project/
+├── src/utttrlsim/          # 既存の環境実装
+│   ├── env.py              # ← UltimateTicTacToeEnv
+│   └── ...
+├── env_registration.py     # ← 新規追加
+├── config.yaml            # ← 新規追加  
+├── train_rl.py            # ← 新規追加
+├── evaluate_rl.py         # ← 新規追加
+├── models/                # 学習済みモデル（自動生成）
+└── logs/                  # TensorBoardログ（自動生成）
+```
+
+## 🔧 高度な使用法
+
+### 分散学習
+```bash
+# 環境数を大幅に増やす
+sed -i 's/n_envs: 8/n_envs: 32/' config.yaml
+python3 train_rl.py
+```
+
+### カスタムコールバック
+`train_rl.py`の`CheckpointCallback`部分を拡張して独自のコールバックを追加可能。
+
+### 他のアルゴリズム
+PPOをA2C、SAC等に変更も簡単：
+```python
+from stable_baselines3 import A2C
+model = A2C("MlpPolicy", vec_env, ...)
+```
+
+---
+
+これで**既存コードに一切手を加えることなく**、強化学習パイプラインが完成です！🎉

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,22 @@
+env_id: UTTTRLSim-v0
+n_envs: 8
+total_steps: 1000000
+seed: 42
+
+ppo_params:
+  learning_rate: 0.0003
+  batch_size: 2048
+  n_steps: 2048
+  ent_coef: 0.01
+  vf_coef: 0.5
+  max_grad_norm: 0.5
+  gamma: 0.99
+  gae_lambda: 0.95
+  clip_range: 0.2
+  policy_kwargs:
+    net_arch: [64, 64]
+
+# ログとモデル保存の設定
+tensorboard_log: logs/tb
+model_path: models/policy.zip
+log_interval: 10

--- a/env_registration.py
+++ b/env_registration.py
@@ -1,0 +1,23 @@
+"""
+自作環境を Gymnasium に登録するだけのファイル。
+置き場所は自由。train_rl.py の先頭で import しておく。
+"""
+
+import gymnasium as gym
+import sys
+import os
+
+# プロジェクトのsrcディレクトリをPythonパスに追加
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+
+# 1. あなたの環境クラスを import
+from utttrlsim import UltimateTicTacToeEnv
+
+# 2. 一度だけ登録（既登録ならスキップ）
+_ENV_ID = "UTTTRLSim-v0"
+
+if _ENV_ID not in gym.envs.registry:
+    gym.register(
+        id=_ENV_ID,
+        entry_point="utttrlsim:UltimateTicTacToeEnv"
+    )

--- a/evaluate_rl.py
+++ b/evaluate_rl.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Ultimate Tic-Tac-Toe 強化学習モデル評価スクリプト
+"""
+
+import gymnasium as gym
+import torch
+import yaml
+import pathlib
+import argparse
+from stable_baselines3 import PPO
+from stable_baselines3.common.evaluation import evaluate_policy
+
+# ★忘れずに環境登録
+import env_registration
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Ultimate Tic-Tac-Toe RL Model Evaluation")
+    parser.add_argument("--model", type=str, default="models/policy.zip", 
+                        help="Path to trained model")
+    parser.add_argument("--episodes", type=int, default=100, 
+                        help="Number of evaluation episodes")
+    parser.add_argument("--render", action="store_true", 
+                        help="Render episodes")
+    args = parser.parse_args()
+    
+    # 設定読み込み
+    config_path = pathlib.Path(__file__).parent / "config.yaml"
+    if config_path.exists():
+        with open(config_path, 'r', encoding='utf-8') as f:
+            cfg = yaml.safe_load(f)
+        env_id = cfg["env_id"]
+        model_path = cfg.get("model_path", args.model)
+    else:
+        env_id = "UTTTRLSim-v0"
+        model_path = args.model
+    
+    # デバイス選択
+    if torch.backends.mps.is_available():
+        device = "mps"
+        print("Using Metal Performance Shaders (MPS) backend")
+    elif torch.cuda.is_available():
+        device = "cuda"
+        print("Using CUDA backend")  
+    else:
+        device = "cpu"
+        print("Using CPU backend")
+    
+    # --- モデル読み込み ---
+    print(f"Loading model from {model_path}")
+    try:
+        model = PPO.load(model_path, device=device)
+        print("Model loaded successfully!")
+    except FileNotFoundError:
+        print(f"Error: Model file not found at {model_path}")
+        print("Please train a model first using train_rl.py")
+        return
+    
+    # --- 環境作成 ---
+    render_mode = "human" if args.render else None
+    env = gym.make(env_id, render_mode=render_mode)
+    
+    print(f"Evaluating model for {args.episodes} episodes...")
+    
+    # --- 評価実行 ---
+    mean_reward, std_reward = evaluate_policy(
+        model, 
+        env, 
+        n_eval_episodes=args.episodes,
+        render=args.render,
+        deterministic=True
+    )
+    
+    # --- 結果出力 ---
+    print(f"\n=== Evaluation Results ===")
+    print(f"Episodes: {args.episodes}")
+    print(f"Mean reward: {mean_reward:.2f} ± {std_reward:.2f}")
+    
+    # 追加統計情報
+    if mean_reward > 0.5:
+        print("🎉 Agent is performing well! (mostly winning)")
+    elif mean_reward > -0.5:
+        print("🤔 Agent is drawing frequently")
+    else:
+        print("😞 Agent needs more training (mostly losing)")
+    
+    env.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/train_rl.py
+++ b/train_rl.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""
+Ultimate Tic-Tac-Toe 強化学習トレーニングスクリプト
+"""
+
+import yaml
+import torch
+import os
+import pathlib
+from stable_baselines3 import PPO
+from stable_baselines3.common.vec_env import make_vec_env
+from stable_baselines3.common.callbacks import CheckpointCallback
+
+# ← 自作環境を Gym 登録しておく
+import env_registration
+
+def main():
+    # --- 設定読み込み（スクリプトと同じ場所の YAML を想定） ---
+    config_path = pathlib.Path(__file__).with_suffix(".yaml")
+    if not config_path.exists():
+        config_path = pathlib.Path(__file__).parent / "config.yaml"
+    
+    with open(config_path, 'r', encoding='utf-8') as f:
+        cfg = yaml.safe_load(f)
+    
+    # ディレクトリ作成
+    os.makedirs(os.path.dirname(cfg["model_path"]), exist_ok=True)
+    os.makedirs(cfg["tensorboard_log"], exist_ok=True)
+    
+    # --- VecEnv 生成 ---
+    print(f"Creating {cfg['n_envs']} environments...")
+    vec_env = make_vec_env(
+        cfg["env_id"],
+        n_envs=cfg["n_envs"],
+        seed=cfg["seed"],
+    )
+    
+    # デバイス選択 (Apple Silicon対応)
+    if torch.backends.mps.is_available():
+        device = "mps"
+        print("Using Metal Performance Shaders (MPS) backend")
+    elif torch.cuda.is_available():
+        device = "cuda"
+        print("Using CUDA backend")
+    else:
+        device = "cpu"
+        print("Using CPU backend")
+    
+    # --- モデル作成 ---
+    print("Creating PPO model...")
+    model = PPO(
+        "MlpPolicy",
+        vec_env,
+        device=device,
+        verbose=1,
+        tensorboard_log=cfg["tensorboard_log"],
+        **cfg["ppo_params"]
+    )
+    
+    # --- コールバック設定 ---
+    checkpoint_callback = CheckpointCallback(
+        save_freq=cfg["total_steps"] // 10,  # 10回チェックポイントを保存
+        save_path=os.path.dirname(cfg["model_path"]),
+        name_prefix="uttt_rl_model"
+    )
+    
+    # --- 学習実行 ---
+    print(f"Starting training for {cfg['total_steps']} steps...")
+    model.learn(
+        total_timesteps=cfg["total_steps"],
+        log_interval=cfg.get("log_interval", 10),
+        callback=checkpoint_callback
+    )
+    
+    # --- モデル保存 ---
+    print(f"Saving final model to {cfg['model_path']}")
+    model.save(cfg["model_path"])
+    
+    print("Training completed!")
+    print(f"TensorBoard logs: {cfg['tensorboard_log']}")
+    print(f"Model saved: {cfg['model_path']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
A reinforcement learning pipeline was established by adding four new files and one documentation file, without modifying the existing project structure.

*   `env_registration.py` was created to register the `UltimateTicTacToeEnv` from `src/utttrlsim` with Gymnasium under the ID `UTTTRLSim-v0`.
    *   It includes `sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))` to ensure the `utttrlsim` module is discoverable regardless of the script's location.
*   `config.yaml` was added to centralize hyperparameters, environment ID, and output paths (`models/policy.zip`, `logs/tb`).
*   `train_rl.py` was implemented as the main training script.
    *   It loads configurations from `config.yaml`.
    *   Utilizes `make_vec_env` for parallel environment interaction.
    *   Includes automatic device detection for MPS (Apple Silicon), CUDA, or CPU.
    *   Integrates `CheckpointCallback` for periodic model saving and TensorBoard logging.
*   `evaluate_rl.py` was added for evaluating trained policies.
    *   It loads the model from the path specified in `config.yaml` or a default.
    *   Supports optional rendering and customizable evaluation episodes via command-line arguments.
*   `RL_SETUP.md` was created to provide a comprehensive guide for setup, usage, customization, and troubleshooting.

The new scripts (`train_rl.py`, `evaluate_rl.py`) were made executable. This setup allows for training and evaluation by simply adding these files and installing dependencies.